### PR TITLE
Enable date and time strings to show more cleary for user

### DIFF
--- a/public/javascripts/question.js
+++ b/public/javascripts/question.js
@@ -9,6 +9,7 @@ jQuery(function ($) {
 
 			if (buttonId === "show-all-questions") {
 				val = "";
+				$("#search-input").val("");
 			}
 			else {
 				val = $.trim($("#search-input").val()).replace(/ +/g, ' ').toLowerCase();
@@ -16,7 +17,7 @@ jQuery(function ($) {
 
 			var rows = $("tbody tr");
 		    rows.hide().filter(function () {
-		        var text = $(this).find('td').slice(0,2).text().replace(/\s+/g, ' ').toLowerCase();
+		        var text = $(this).find('td').slice(2,3).text().replace(/\s+/g, ' ').toLowerCase();
 
 		        return text.indexOf(val) != -1 ;
 		    }).show();

--- a/routes/index.js
+++ b/routes/index.js
@@ -295,54 +295,32 @@ exports.session = teacherRequest(function(req, res) {
 
 			// Sort sessions by end time and then pass in sessions into
 			// the 'session' template.
-			
 			sessions.sort(function(a, b) {
 			    a = new Date(a.startTime);
 			    b = new Date(b.startTime);
 			    return a>b ? -1 : a<b ? 1 : 0;
 			});
 
-			var sessionTimes = [];
 
+			// Add date, start time, and end time strings to make it easier for the user to read
+			// for each session.
 			for (var i = 0; i < sessions.length; i++) {
-				// sessions[i].startTime = 0;
-
 				var startTime = new Date(sessions[i].startTime);
 				var endTime = new Date(sessions[i].endTime);
-				console.log("startTime is " + startTime);
 
 				var dateString = formatDate(startTime);
-
-				console.log("dateString is " + dateString);
 				var startTimeString = formatAMPM(startTime);
 				var endTimeString = formatAMPM(endTime);
-
-				var sessionTime = {};
-				sessionTime.dateString = dateString;
-				sessionTime.startTime = startTimeString;
-				sessionTime.endTime = endTimeString;
-
-				sessionTimes.push(sessionTime);
 
 				sessions[i].dateString = dateString;
 				sessions[i].startTimeString = startTimeString;
 				sessions[i].endTimeString = endTimeString;
-
-
-				// var dateSplit = dateString.split(" ");
-				// console.log("dateSplit is " + dateSplit);
-
-				// var sT= sessions[i].startTime;
-				// console.log("sessions[i].startTime instanceof Date == " + sessions[i].startTime instanceof Date);
-				// console.log("typeof sessions[i].startTime == " + typeof sessions[i].startTime);
-				// console.log("session time is " + sT);
 			}
 
 
 			res.render('session', {
 				title: 'Session',
 				classroom: classroom,
-				sessionTimes: sessionTimes,
 				sessions: sessions,
 				partials: {
 					layout: 'layout'

--- a/routes/index.js
+++ b/routes/index.js
@@ -184,6 +184,105 @@ function checkIfSessionIsActive(sessions){
 	}
 }
 
+function formatAMPM(date) {
+  var hours = date.getHours();
+  var minutes = date.getMinutes();
+  var ampm = hours >= 12 ? 'pm' : 'am';
+  hours = hours % 12;
+  hours = hours ? hours : 12; // the hour '0' should be '12'
+  minutes = minutes < 10 ? '0'+minutes : minutes;
+  var strTime = hours + ':' + minutes + ' ' + ampm;
+  return strTime;
+}
+
+function findDayOfWeek(day) {
+	var dayOfWeek;
+
+	switch (day) {
+		case 0:
+			dayOfWeek = "Sunday";
+			break;
+		case 1:
+			dayOfWeek = "Monday";
+			break;
+		case 2:
+			dayOfWeek = "Tuesday";
+			break;
+		case 3:
+			dayOfWeek = "Wednesday";
+			break;
+		case 4:
+			dayOfWeek = "Thursday";
+			break;
+		case 5:
+			dayOfWeek = "Friday";
+			break;
+		case 6:
+			dayOfWeek = "Saturday";
+			break;
+	}
+
+	return dayOfWeek;
+
+}
+
+function findMonth(monthInt) {
+	var month;
+
+	switch (monthInt) {
+		case 0:
+			month = "January";
+			break;
+		case 1:
+			month = "February";
+			break;
+		case 2:
+			month = "March";
+			break;
+		case 3:
+			month = "April";
+			break;
+		case 4:
+			month = "May";
+			break;
+		case 5:
+			month = "June";
+			break;
+		case 6:
+			month = "July";
+			break;
+		case 7:
+			month = "August";
+			break;
+		case 8:
+			month = "September";
+			break;
+		case 9:
+			month = "October";
+			break;
+		case 10:
+			month = "November";
+			break;
+		case 11:
+			month = "December";
+			break;
+	}
+
+	return month;
+}
+
+
+function formatDate(date) {
+	var month = findMonth(date.getMonth());
+	var day = findDayOfWeek(date.getDay());
+	var date = date.getDate();
+	console.log("month is " + month);
+	console.log("day is " + day);
+	var strMonth = day + ", " + month + " " + date;
+	console.log("strMonth is " + strMonth);
+	return strMonth;
+}
+
 exports.session = teacherRequest(function(req, res) {
 	var cid = req.query.cid;
 	console.log(req.query);
@@ -203,15 +302,47 @@ exports.session = teacherRequest(function(req, res) {
 			    return a>b ? -1 : a<b ? 1 : 0;
 			});
 
+			var sessionTimes = [];
+
 			for (var i = 0; i < sessions.length; i++) {
-				var sT= sessions[i].startTime;
-				console.log("session time is " + sT);
+				// sessions[i].startTime = 0;
+
+				var startTime = new Date(sessions[i].startTime);
+				var endTime = new Date(sessions[i].endTime);
+				console.log("startTime is " + startTime);
+
+				var dateString = formatDate(startTime);
+
+				console.log("dateString is " + dateString);
+				var startTimeString = formatAMPM(startTime);
+				var endTimeString = formatAMPM(endTime);
+
+				var sessionTime = {};
+				sessionTime.dateString = dateString;
+				sessionTime.startTime = startTimeString;
+				sessionTime.endTime = endTimeString;
+
+				sessionTimes.push(sessionTime);
+
+				sessions[i].dateString = dateString;
+				sessions[i].startTimeString = startTimeString;
+				sessions[i].endTimeString = endTimeString;
+
+
+				// var dateSplit = dateString.split(" ");
+				// console.log("dateSplit is " + dateSplit);
+
+				// var sT= sessions[i].startTime;
+				// console.log("sessions[i].startTime instanceof Date == " + sessions[i].startTime instanceof Date);
+				// console.log("typeof sessions[i].startTime == " + typeof sessions[i].startTime);
+				// console.log("session time is " + sT);
 			}
 
 
 			res.render('session', {
 				title: 'Session',
 				classroom: classroom,
+				sessionTimes: sessionTimes,
 				sessions: sessions,
 				partials: {
 					layout: 'layout'

--- a/routes/index.js
+++ b/routes/index.js
@@ -293,8 +293,8 @@ exports.session = teacherRequest(function(req, res) {
 		Session.find({"_id": { $in: sessionIds}}, function(err, sessions) {
 			checkIfSessionIsActive(sessions);
 
-			// Sort sessions by end time and then pass in sessions into
-			// the 'session' template.
+			// Sort sessions by start time with the more recent sessions
+			// displayed first. 
 			sessions.sort(function(a, b) {
 			    a = new Date(a.startTime);
 			    b = new Date(b.startTime);
@@ -347,6 +347,26 @@ exports.questions = teacherRequest(function(req, res) {
 		var questionIds = session.questions;
 
 		Question.find({"_id": { $in: questionIds}}, function(err, questions) {
+
+			// Sort questions by time asked with the most recently asked questions 
+			// displayed first.
+			questions.sort(function(a, b) {
+			    a = new Date(a.timeAsked);
+			    b = new Date(b.timeAsked);
+			    return a>b ? -1 : a<b ? 1 : 0;
+			});
+
+
+			// Add date and time asked strings to make strings easier to read for user.
+			for (var i = 0; i < questions.length; i++) {
+				var startTime = new Date(questions[i].timeAsked);
+			
+				var dateString = formatDate(startTime);
+				var timeAskedString = formatAMPM(startTime);
+
+				questions[i].dateString = dateString;
+				questions[i].timeAskedString = timeAskedString;
+			}
 
 			res.render('question', {
 				title: 'Questions',

--- a/views/question.hjs
+++ b/views/question.hjs
@@ -31,6 +31,7 @@
 
         <thead>
        		<tr>
+                <th>Date</th>
 				<th>Time Asked</th>
 				<th>Content</th>
 				<th>Was Answered</th>
@@ -39,7 +40,8 @@
         <tbody>
             {{#questions}}
 			<tr>
-				<td>{{timeAsked}}</td>
+                <td>{{dateString}}</td>
+				<td>{{timeAskedString}}</td>
 				<td>{{content}}</td>
 				<td>
 					{{#isAnswered}}{{isAnswered}}{{/isAnswered}}
@@ -50,11 +52,7 @@
         </tbody>
     </table>
     </form>
-    <div class="row">
-
-	</div>
 </div>
 {{/body}}
 
 {{/layout}}
-`

--- a/views/session.hjs
+++ b/views/session.hjs
@@ -12,8 +12,9 @@
 	<table class="table table-hover">
 		<thead>
 			<tr>
-				<th>Start</th>
-				<th>End</th>
+				<th>Date</th>
+				<th>Start Time</th>
+				<th>End Time</th>
 				<th>Active</th>
 				<th>Questions asked</th>
 				<th>Questions answered</th>
@@ -23,8 +24,9 @@
 		<tbody>
 			{{#sessions}}
 			<tr>
-				<td><a href="/question?sid={{id}}&classroomName={{classroom.name}}">{{startTime}}</a></td>
-				<td>{{endTime}}</td>
+				<td><a href="/question?sid={{id}}&classroomName={{classroom.name}}">{{dateString}}</a></td>
+				<td>{{startTimeString}}</td>
+				<td>{{endTimeString}}</td>
 				<td>
 					{{#active}}Yes{{/active}}
 					{{^active}}No{{/active}}


### PR DESCRIPTION
This PR makes the date and time strings easier to read users. Here's what the sessions page now looks like:
![screen shot 2015-04-09 at 4 49 45 pm](https://cloud.githubusercontent.com/assets/5490475/7079389/a0320fb2-ded8-11e4-8689-47090c08a0bf.png)

In addition, here's what the questions page now looks like:

![screen shot 2015-04-09 at 4 49 59 pm](https://cloud.githubusercontent.com/assets/5490475/7079395/a95c2b36-ded8-11e4-9b78-92efd48803b9.png)
