### PR TITLE
Subtract 7 hours from time to reflect Arizona time

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -305,6 +305,10 @@ exports.session = teacherRequest(function(req, res) {
 				var startTime = new Date(sessions[i].startTime);
 				var endTime = new Date(sessions[i].endTime);
 
+				// Subtract 7 hours.
+				startTime.setHours(startTime.getHours() - 7);
+				endTime.setHours(endTime.getHours() - 7);
+
 				var dateString = formatDate(startTime);
 				var startTimeString = formatAMPM(startTime);
 				var endTimeString = formatAMPM(endTime);


### PR DESCRIPTION
This PR subtracts 7 hours from the time saved in the database so that the app deployed on Heroku App shows the correct time.
