### PR TITLE
Alter session lengths to include sessions of length 5, 15, 30, 60, and 75 minutes

### DIFF
--- a/views/createSession.hjs
+++ b/views/createSession.hjs
@@ -18,16 +18,16 @@
 					<input type="radio" id="q156" name="duration" value="5" /> 5min.
 					</label>
 					<label class="btn btn-default btn-lg">
-					<input type="radio" id="q157" name="duration" value="10" /> 10min.
+					<input type="radio" id="q157" name="duration" value="15" /> 15min.
 					</label>
 					<label class="btn btn-default btn-lg active">
-					<input type="radio" id="q158" name="duration" checked="checked" value="15" /> 15min.
+					<input type="radio" id="q158" name="duration" checked="checked" value="30" /> 30min.
 					</label>
 					<label class="btn btn-default btn-lg">
-					<input type="radio" id="q159" name="duration" value="20" /> 20min.
+					<input type="radio" id="q159" name="duration" value="60" /> 60min.
 					</label>
 					<label class="btn btn-default btn-lg">
-					<input type="radio" id="q160" name="duration" value="25" /> 25min.
+					<input type="radio" id="q160" name="duration" value="75" /> 75min.
 					</label>
 					</div>
 					<input type="hidden" name="cid" value="{{cid}}">


### PR DESCRIPTION
This PR gives users more variety in the length of their session lengths. A screenshot of what the user will see when creating a session is shown below:
![screen shot 2015-04-18 at 8 13 09 pm](https://cloud.githubusercontent.com/assets/5490475/7218009/c3ba9428-e607-11e4-826f-1dcc42bc2b65.png)
