### PR TITLE
Removed 'Find Keywords' option and fixed question asked times

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -392,6 +392,9 @@ exports.feedback = teacherRequest(function(req, res) {
 							// Add date and time asked strings to make strings easier to read for user.
 							for (var i = 0; i < questions.length; i++) {
 								var startTime = new Date(questions[i].timeAsked);
+
+								// // Subtract 7 hours from the time to represent Arizona time.
+								startTime.setHours(startTime.getHours() - 7);
 							
 								var dateString = formatDate(startTime);
 								var timeAskedString = formatAMPM(startTime);

--- a/routes/index.js
+++ b/routes/index.js
@@ -406,6 +406,7 @@ exports.feedback = teacherRequest(function(req, res) {
 							res.render('feedback', {
 								title: 'Feedback',
 								classroomName: classroomName,
+								sessionId: sid,
 								totalQuestionsAnswered: totalQuestionsAnswered,
 								totalQuestionsAsked: totalQuestionsAsked,
 								numberOfKeywords: numberOfKeywords,

--- a/views/feedback.hjs
+++ b/views/feedback.hjs
@@ -28,7 +28,7 @@
             </tbody>
         </table>
 
-
+    <a href="/feedback/createFeedback?sid={{sessionId}}&classroomName={{classroomName}}" class="btn btn-info"><span class="glyphicon glyphicon-plus"></span> Update Feedback</a>
 	<form id="search">
         <h4>Questions</h4>
         <div class="row">

--- a/views/session.hjs
+++ b/views/session.hjs
@@ -18,7 +18,6 @@
 				<th>Active</th>
 				<th>Questions asked</th>
 				<th>Questions answered</th>
-				<th>Top keyword</th>
 			</tr>
 		</thead>
 		<tbody>
@@ -39,7 +38,6 @@
 					{{#ratio}}{{ratio}}{{/ratio}}
 					{{^ratio}}0{{/ratio}}
 				</td>
-				<td><a href="/feedback/getKeywords?sid={{id}}" class="btn btn-info">Find Keywords</a></td>
 			</tr>
 			{{/sessions}}
 		</tbody>


### PR DESCRIPTION
This PR address some minor fixes. It removes the 'Find Keywords' option for each session (which was meant mainly for testing) and it also outputs the time at which questions were asked to be in Arizona time.
